### PR TITLE
fix markdown code block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Generate project Use tupaijs command.
     tupaijs new helloworld
 
 Start server.
+
     cd helloworld; tupaijs server
 
 Open in browser.


### PR DESCRIPTION
Github上の画面でMarkdownが正しく表示されていなかったのを修正しました。