### PR TITLE
enable to server separated files on tupaijs server

### DIFF
--- a/examples/helloworld/web/index.html
+++ b/examples/helloworld/web/index.html
@@ -5,7 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <meta name="format-detection" content="telephone=no">
 <link rel="stylesheet" href="css/base.css">
+
+
+<!-- __tupai_files__ -->
 <script src="js/tupai.min.js"></script>
+<!-- __tupai_files__ -->
+
 <!-- __js_files__ -->
 <script src="js/helloworld.js"></script>
 <!-- __js_files__ -->

--- a/scripts/nodejs/server.js
+++ b/scripts/nodejs/server.js
@@ -61,12 +61,12 @@ function listTupaiClass(callback) {
         //if (!output) {return;}
         var classes = JSON.parse(output);
         //console.log(classes);
-        var tupaijsfiles = classes.map(function(cls){
+        var scripts = classes.map(function(cls){
             var path = cls.path;
-            return path.replace(tupaiSrcDir + "/", "");
+            var filename = path.replace(tupaiSrcDir + "/", "");
+            return '<script src="__tupairoot/src/tupai/' + filename + '"></script>';
         });
 
-        var scripts = tupaijsfiles.map(function(filename){ return '<script src="__tupairoot/src/tupai/' + filename + '"></script>';});
         tupaiFilesHtml = packagejsHtml + "\n" + scripts.join("\n");
 
         callback();


### PR DESCRIPTION
# BACKGROUND

Serving a single tupai.min.js is useful in the production environment, but it makes difficulties for newbies to understand and investigate tupai.js internals.

# SOLUTION

This PR provide a feature that replaces a partial HTML  wrapped by `<!-- __tupai_files__ -->...<!-- __tupai_files__ -->`  by  all separated single '<script src="..."></script>' elements.

for example:
```
<script src="__tupairoot/libs/package.js"></script>
<script src="__tupairoot/src/tupai/Application.js"></script>
<script src="__tupairoot/src/tupai/PushStateTransitManager.js"></script>
<script src="__tupairoot/src/tupai/TransitManager.js"></script>
<script src="__tupairoot/src/tupai/ViewController.js"></script>
<script src="__tupairoot/src/tupai/Window.js"></script>
<script src="__tupairoot/src/tupai/animation/TransitAnimation.js"></script>
<script src="__tupairoot/src/tupai/animation/Transition.js"></script>
<script src="__tupairoot/src/tupai/events/Events.js"></script>
<script src="__tupairoot/src/tupai/model/ApiManager.js"></script>
<script src="__tupairoot/src/tupai/model/CacheManager.js"></script>
<script src="__tupairoot/src/tupai/model/DataSet.js"></script>
<script src="__tupairoot/src/tupai/model/caches/HashCache.js"></script>
<script src="__tupairoot/src/tupai/model/caches/HashCacheDataSet.js"></script>
<script src="__tupairoot/src/tupai/model/caches/QueueCache.js"></script>
<script src="__tupairoot/src/tupai/model/caches/QueueCacheDataSet.js"></script>
<script src="__tupairoot/src/tupai/net/HttpClient.js"></script>
<script src="__tupairoot/src/tupai/net/HttpRequest.js"></script>
<script src="__tupairoot/src/tupai/net/JsonpClient.js"></script>
<script src="__tupairoot/src/tupai/ui/TableView.js"></script>
<script src="__tupairoot/src/tupai/ui/TemplateEngine.js"></script>
<script src="__tupairoot/src/tupai/ui/TemplateView.js"></script>
<script src="__tupairoot/src/tupai/ui/Templates.js"></script>
<script src="__tupairoot/src/tupai/ui/View.js"></script>
<script src="__tupairoot/src/tupai/ui/ViewEvents.js"></script>
<script src="__tupairoot/src/tupai/util/CommonUtil.js"></script>
<script src="__tupairoot/src/tupai/util/HashUtil.js"></script>
<script src="__tupairoot/src/tupai/util/HttpUtil.js"></script>
<script src="__tupairoot/src/tupai/util/LinkedList.js"></script>
<script src="__tupairoot/src/tupai/util/MemCache.js"></script>
<script src="__tupairoot/src/tupai/util/UserAgent.js"></script>
```