### PR TITLE
indent template properties

### DIFF
--- a/scripts/phantomjs/build_template.js
+++ b/scripts/phantomjs/build_template.js
@@ -64,8 +64,9 @@ function writeToFile() {
     stream.write('Package(\'' + packageName + '\')\n');
     stream.write('.define(\'' + className + '\', function(cp) {\n');
 
-    stream.write('var _templates = ');
-    stream.write(JSON.stringify(templates));
+    stream.write('  var _templates = ');
+    var jsonString = JSON.stringify(templates, null, "    ");
+    stream.write(jsonString);
     stream.write(';\n');
 
     //footer

--- a/scripts/phantomjs/build_template.js
+++ b/scripts/phantomjs/build_template.js
@@ -65,7 +65,7 @@ function writeToFile() {
     stream.write('.define(\'' + className + '\', function(cp) {\n');
 
     stream.write('  var _templates = ');
-    var jsonString = JSON.stringify(templates, null, "    ");
+    var jsonString = JSON.stringify(templates, undefined, 4);
     stream.write(jsonString);
     stream.write(';\n');
 


### PR DESCRIPTION
This PR makes template classes more readable.

```js
Package('example')
.define('FooTemplates', function(cp) {
  var _templates = {
    "root": "<div>\n    <div data-ch-id=......",
    "bar": "<div>\n    ......",
```