### PR TITLE
display error on executing phantom failure

### DIFF
--- a/scripts/nodejs/templates.js
+++ b/scripts/nodejs/templates.js
@@ -28,6 +28,9 @@ function compileTemplate(url, output, packageName, options) {
             onStdoutData: options.onStdoutData,
             onStderrData: options.onStderrData,
             end: function(code) {
+                if (code !== 0) {
+                    throw new Error('executing phantomjs failed.');
+                }
                 end && end(code, url);
             }
         });


### PR DESCRIPTION
this PR improves error message.

# Before
```
gen configs:
    create gen/configs/Config.js
    create gen/configs/i18n/I18n.js
gen template files:
    templates -> gen/templates
{ [Error: spawn ENOENT] code: 'ENOENT', errno: 'ENOENT', syscall: 'spawn' }
start watching files:
    watching src
    watching templates
    watching configs
proxies:
    /api -> http://localhost:8086/api

open below url in your browser.
http://localhost:30002
```

# After
```
gen configs:
    create gen/configs/Config.js
    create gen/configs/i18n/I18n.js
gen template files:
    templates -> gen/templates
{ [Error: spawn ENOENT] code: 'ENOENT', errno: 'ENOENT', syscall: 'spawn' }

example/node_modules/tupaijs/scripts/nodejs/templates.js:32
                    throw new Error('executing phantomjs failed.');
                          ^
Error: executing phantomjs failed.
    at Object.tupai.execute.end (example/node_modules/tupaijs/scripts/nodejs/templates.js:32:27)
    at example/node_modules/tupaijs/scripts/nodejs/index.js:65:21
    at process._tickCallback (node.js:419:13)
```
