### PR TITLE
change priority of proxy

### DIFF
--- a/scripts/nodejs/server.js
+++ b/scripts/nodejs/server.js
@@ -187,7 +187,6 @@ function configDebugMode(app) {
     var webDir = path.join(__dirname, '..', '..', 'releases', mConfig.web);
     //console.log(mConfig);
 
-    useProxyRequest(app);
     app.use('/__js', express.static(mConfig.sources));
     app.use('/__js', express.static(mConfig.genTemplates));
     app.use('/__js', express.static(mConfig.genConfigs));
@@ -217,6 +216,7 @@ function configDebugMode(app) {
         }
     });
 
+    useProxyRequest(app);
     var tupaiRootDir = path.join(__dirname, '..', '..');
     app.use('/__tupairoot', express.static(tupaiRootDir));
 


### PR DESCRIPTION
# Current Issue

When user specifies proxy like below in a server config file,

my.tupai.conf
```
    "proxies": {
        "/": "http://10.0.0.2:8084/"
    },
```

tupai js server does not replace `__js_files__` and `__tupai_files__` , 

because  the proxy setting overwrite the routing

```
app.use('/', function(req, res, next) {
```
https://github.com/deyunanhai/tupai.js/blob/master/scripts/nodejs/server.js#L194

# What this PR solves

tupaijs server can handle user proxy '/' as expected, and also handle requests to '*.html' properly

