### PR TITLE
"phantomjs" is deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,24 +17,24 @@
   "scripts": {
     "test": "NODE_ENV=test ./tests/run.js"
   },
-  "licenses" : [
+  "licenses": [
     {
-      "type" : "MIT",
-      "url" : "http://tupaijs.com/license.html"
+      "type": "MIT",
+      "url": "http://tupaijs.com/license.html"
     }
   ],
   "readmeFilename": "README.md",
-  "dependencies" : {
-    "phantomjs": "1.9.0-3",
-    "html-minifier": "0.6.9",
-    "yuicompressor": "2.4.8",
-    "ejs": "0.8.4",
-    "mkdirp": "0.3.5",
-    "temp": "0.5.1",
+  "dependencies": {
     "chokidar": "1.2.0",
     "commander": "2.0.0",
+    "ejs": "0.8.4",
     "express": "3.3.1",
-    "http-proxy": "1.12.0"
+    "html-minifier": "0.6.9",
+    "http-proxy": "1.12.0",
+    "mkdirp": "0.3.5",
+    "phantomjs-prebuilt": "^2.1.12",
+    "temp": "0.5.1",
+    "yuicompressor": "2.4.8"
   },
   "devDependencies": {
     "karma": "0.8.7"


### PR DESCRIPTION
https://www.npmjs.com/package/phantomjs

> DEPRECATED
> Pre-2.0, this package was published to NPM as phantomjs. We changed the name to phantomjs-prebuilt at the request of PhantomJS team.
> Please update your package references from phantomjs to phantomjs-prebuilt

use https://www.npmjs.com/package/phantomjs-prebuilt