### PR TITLE
Support node.js v10 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "html-minifier": "0.6.9",
     "http-proxy": "1.12.0",
     "mkdirp": "0.3.5",
-    "phantomjs-prebuilt": "^2.1.12",
+    "phantomjs-prebuilt": "^2.1.16",
     "temp": "0.5.1",
     "yuicompressor": "2.4.8"
   },

--- a/scripts/nodejs/templates.js
+++ b/scripts/nodejs/templates.js
@@ -53,7 +53,7 @@ function compileTemplate(url, output, packageName, options) {
                 }
                 var tempUrl = info.path;
                 compile(tempUrl, function(code) {
-                    fs.unlink(tempUrl);
+                    fs.unlinkSync(tempUrl);
                     options && options.end && options.end(code, url);
                 });
             });


### PR DESCRIPTION
From the above versions, calling fs module functions without callback will fail. I fixed that and used the latest version of phantomjs-prebuilt.