### PR TITLE
Upgrade temp package version to update use of deprecated Node.js API

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "http-proxy": "1.12.0",
     "mkdirp": "0.3.5",
     "phantomjs-prebuilt": "^2.1.16",
-    "temp": "0.5.1",
+    "temp": "^0.6.0",
     "yuicompressor": "2.4.8"
   },
   "devDependencies": {


### PR DESCRIPTION
With this update, deprecated `os.tmpDir` used in `temp` package will be replaced with `os.tmpdir`. This will enable building application with Node.js >= 14, while it is compatible with Node.js 10. 